### PR TITLE
Parse modelica standard library down to 2 fails.

### DIFF
--- a/lib/Grammar/Modelica.pm6
+++ b/lib/Grammar/Modelica.pm6
@@ -1,6 +1,10 @@
 #!perl6
 
 use v6;
+
+#no precompilation; # GH grammar-debugger issue #40
+#use Grammar::Tracer;
+
 use Grammar::Modelica::LexicalConventions;
 use Grammar::Modelica::ClassDefinition;
 use Grammar::Modelica::Extends;
@@ -20,7 +24,7 @@ unit grammar Grammar::Modelica
 
 rule TOP {^ <within>?<class_def>* $}
 
-rule within { <|w>'within'<|w> <name> ';' }
+rule within { <|w>'within'<|w> <name>? ';' }
 
 rule class_def { [<|w>'final'<|w>]? <class_definition> ';' }
 

--- a/lib/Grammar/Modelica/ClassDefinition.pm6
+++ b/lib/Grammar/Modelica/ClassDefinition.pm6
@@ -9,7 +9,7 @@ rule class_definition { [<|w>$<encapsulated>='encapsulated'<|w>]? <class_prefixe
 rule class_prefixes { $<partial>=(<|w>'partial'<|w>)? <|w>( 'class' || 'model' || [ 'operator'? <|w>'record' ] ||
   'block' || [ 'expandable'? <|w>'connector'] || 'type' || 'package' || [[ 'pure' | 'impure' ]? [<|w>'operator'?] <|w>'function'] ||
   'operator'
-) <|w> }
+) <!ww> }
 
 token class_specifier {<long_class_specifier>||<short_class_specifier>||<der_class_specifier>}
 

--- a/lib/Grammar/Modelica/Equations.pm6
+++ b/lib/Grammar/Modelica/Equations.pm6
@@ -103,7 +103,7 @@ rule when_statement {
   <|w>'when'<|w> <expression> <|w>'then'<|w>
   [ <statement> ';' ]*
   [
-  <|w>'elsewhen'<|w> <expression> <|w>'then'<|w><|w><|w>
+  <|w>'elsewhen'<|w> <expression> <|w>'then'<|w>
   [ <statement> ';' ]*
   ]*
   <|w>'end'<|w> <|w>'when'<|w>

--- a/lib/Grammar/Modelica/Expressions.pm6
+++ b/lib/Grammar/Modelica/Expressions.pm6
@@ -58,7 +58,7 @@ rule primary {
   <STRING> ||
   <|w>'false'<|w> ||
   <|w>'true'<|w> ||
-  [ [<name>||'der'||'initial'] <function_call_args> ] ||
+  [ [<component_reference>||'der'||'initial'||'pure'] <function_call_args> ] ||
   <component_reference> ||
   [ '(' <output_expression_list> ')' ] ||
   [ '[' <expression_list> [ ';' <expression_list> ]* ']' ] ||
@@ -78,7 +78,7 @@ rule function_call_args {
   '(' <function_arguments>? ')'
 }
 
-rule function_arguments {
+regex function_arguments {:s
   [ <expression> [ [ ',' <function_arguments_non_first> ] || [ <|w>'for'<|w> <for_indices>] ]? ]
   ||
   [ <|w>'function'<|w> <name> '(' <named_arguments>? ')'  [ ',' <function_arguments_non_first> ]? ]
@@ -86,7 +86,7 @@ rule function_arguments {
   <named_arguments>
 }
 
-rule function_arguments_non_first {
+regex function_arguments_non_first {:s
   [ <function_argument> [ ',' <function_arguments_non_first> ]? ]
   ||
   <named_arguments>
@@ -116,7 +116,7 @@ rule function_argument {
 }
 
 rule output_expression_list {
-  <expression>? [ ',' <expression> ]*
+  <expression>? [ ',' <expression>? ]*
 }
 
 rule expression_list { <expression> [ ',' <expression> ]* }

--- a/lib/Grammar/Modelica/LexicalConventions.pm6
+++ b/lib/Grammar/Modelica/LexicalConventions.pm6
@@ -4,7 +4,9 @@ use v6;
 
 unit role Grammar::Modelica::LexicalConventions;
 
-token BASEIDENT {[[<|w><NONDIGIT>[<DIGIT>||<NONDIGIT>]*]<|w>||<Q-IDENT>]<!after <|w><keywords>>}
+token BASEIDENT {[[<|w><NONDIGIT>[<DIGIT>||<NONDIGIT>]*]<|w>||<Q-IDENT>]}
+# See GH rakudo issue #1659.  Not in spec and looks covered by IDENT.
+# token BASEIDENT {...<!after <|w><keywords>>}
 
 token Q-IDENT {<[']>[<Q-CHAR>||<S-ESCAPE>]+<[']>}
 

--- a/t/Expressions.t
+++ b/t/Expressions.t
@@ -5,7 +5,7 @@ use Test;
 use lib '../lib';
 use Grammar::Modelica;
 
-plan 169;
+plan 168;
 
 grammar TestExpression is Grammar::Modelica {
   rule TOP {^ <expression> $}
@@ -182,7 +182,6 @@ nok TestFactor.parse('primary^primary^primary');
 grammar TestPrimary is Grammar::Modelica {
   rule TOP {^<primary>$}
   rule function_call_args {'function_call_args'}
-  rule component_reference {'component_reference'}
   rule output_expression_list {'output_expression_list'}
   rule expression_list {'expression_list'}
   rule array_arguments {'array_arguments'}
@@ -194,7 +193,6 @@ ok TestPrimary.parse('true');
 ok TestPrimary.parse('valid_name function_call_args');
 ok TestPrimary.parse('der function_call_args');
 ok TestPrimary.parse('initial function_call_args');
-ok TestPrimary.parse('component_reference');
 ok TestPrimary.parse('(output_expression_list)');
 ok TestPrimary.parse('[expression_list]');
 ok TestPrimary.parse('[expression_list;expression_list]');
@@ -305,7 +303,7 @@ ok TestOutputExpressionList.parse('expression,expression');
 ok TestOutputExpressionList.parse('expression,expression,expression,expression');
 ok TestOutputExpressionList.parse(',expression,expression,expression');
 ok TestOutputExpressionList.parse('expression ,expression, expression , expression');
-nok TestOutputExpressionList.parse('expression ,expression, expression ,');
+ok TestOutputExpressionList.parse('expression ,expression, expression, , expression');
 nok TestOutputExpressionList.parse('expression ,expression expression , expression');
 
 grammar TestExpressionList is Grammar::Modelica {

--- a/t/Modelica.t
+++ b/t/Modelica.t
@@ -14,7 +14,7 @@ ok TestWithin.parse('within valid_name;');
 ok TestWithin.parse('within valid_name ;');
 nok TestWithin.parse('withinvalid_name;');
 nok TestWithin.parse('valid_name;');
-nok TestWithin.parse('within;');
+ok TestWithin.parse('within ;');
 nok TestWithin.parse('within valid_name');
 
 grammar TestClassDef is Grammar::Modelica {


### PR DESCRIPTION
With the changes in these commits all Modelica Standard Library files except 2 pass with parseThemAll.p6 and sot do all tests in `t/`.  See the commit messages for further explanation of what was fixed.