### PR TITLE
Ws cleanup

### DIFF
--- a/examples/parseThemAll.p6
+++ b/examples/parseThemAll.p6
@@ -7,7 +7,7 @@ use Grammar::Modelica;
 # use Grammar::Tracer;
 
 
-plan 305;
+plan 313;
 
 sub light($file) {
   my $fh = open $file, :r;

--- a/lib/Grammar/Modelica.pm6
+++ b/lib/Grammar/Modelica.pm6
@@ -24,8 +24,8 @@ unit grammar Grammar::Modelica
 
 rule TOP {^ <within>?<class_def>* $}
 
-rule within { <|w>'within'<|w> <name>? ';' }
+rule within { 'within' <name>? ';' }
 
-rule class_def { [<|w>'final'<|w>]? <class_definition> ';' }
+rule class_def { 'final'? <class_definition> ';' }
 
 rule bgs { 'cou!!asdfafsd!!'  }

--- a/lib/Grammar/Modelica/ClassDefinition.pm6
+++ b/lib/Grammar/Modelica/ClassDefinition.pm6
@@ -4,24 +4,38 @@ use v6;
 
 unit role Grammar::Modelica::ClassDefinition;
 
-rule class_definition { [<|w>$<encapsulated>='encapsulated'<|w>]? <class_prefixes> <class_specifier> }
+rule class_definition {
+  $<encapsulated>='encapsulated'? <class_prefixes> <class_specifier>
+}
 
-rule class_prefixes { $<partial>=(<|w>'partial'<|w>)? <|w>( 'class' || 'model' || [ 'operator'? <|w>'record' ] ||
-  'block' || [ 'expandable'? <|w>'connector'] || 'type' || 'package' || [[ 'pure' | 'impure' ]? [<|w>'operator'?] <|w>'function'] ||
-  'operator'
-) <!ww> }
+rule class_prefixes {
+  $<partial>=('partial')? [
+    ||  'class'
+    ||  'model'
+    ||  'operator'? 'record'
+    ||  'block'
+    ||  'expandable'? 'connector'
+    ||  'type'
+    ||  'package'
+    ||  [ 'pure' | 'impure' ]? 'operator'? 'function'
+    ||  'operator'
+  ]
+}
 
-token class_specifier {<long_class_specifier>||<short_class_specifier>||<der_class_specifier>}
+token class_specifier {
+  ||  <long_class_specifier>
+  ||  <short_class_specifier>
+  ||  <der_class_specifier>
+}
 
 rule long_class_specifier {
-  [(<IDENT>) <string_comment> <composition> <|w>'end'<|w> $0 ]
-  ||
-  [<|w>'extends'<|w> (<IDENT>) <class_modification>? <string_comment> <composition> <|w>'end'<|w> $0 ]
+  ||  (<IDENT>) <string_comment> <composition> 'end' $0
+  ||  'extends' (<IDENT>) <class_modification>? <string_comment> <composition> 'end' $0
 }
 
 rule short_class_specifier {
-  [<IDENT> '=' <base_prefix> <type_specifier> <array_subscripts>? <class_modification>? <comment>] ||
-  [<IDENT> '=' 'enumeration' '(' [<enum_list>? || ':'] ')' <comment>]
+  ||  <IDENT> '=' <base_prefix> <type_specifier> <array_subscripts>? <class_modification>? <comment>
+  ||  <IDENT> '=' 'enumeration' '(' [ <enum_list>? || ':' ] ')' <comment>
 }
 
 rule der_class_specifier {
@@ -41,13 +55,13 @@ rule enumeration_literal {
 rule composition {
   <element_list>
   [
-  [<|w>'public'<|w> <element_list>] ||
-  [<|w>'protected'<|w> <element_list>] ||
-  <equation_section> ||
-  <algorithm_section>
+  ||  'public' <element_list>
+  ||  'protected' <element_list>
+  ||  <equation_section>
+  ||  <algorithm_section>
   ]*
   [
-  <|w>'external'<|w> <language_specification>? <external_function_call>? <annotation>? ';'
+    'external' <language_specification>? <external_function_call>? <annotation>? ';'
   ]? # optional
   [<annotation> ';']? #optional
 }
@@ -55,7 +69,7 @@ rule composition {
 token language_specification {<STRING>}
 
 rule external_function_call {
-  [<component_reference> '=']?
+  [ <component_reference> '=' ]?
   <IDENT> '(' <expression_list>? ')'
 }
 
@@ -64,22 +78,22 @@ rule element_list {
 }
 
 rule element {
-  <import_clause> ||
-  <extends_clause> ||
-  [<|w>'redeclare'<|w>]? [<|w>'final'<|w>]? [<|w>'inner'<|w>]? [<|w>'outer'<|w>]?
-  [
-    [<class_definition> || <component_clause>] ||
-    <|w>'replaceable'<|w> [<class_definition> || <component_clause>]
-    [<constraining_clause> <comment>]?
+  ||  <import_clause>
+  ||  <extends_clause>
+  ||  'redeclare'? 'final'? 'inner'? 'outer'?  [
+    ||  <class_definition>
+    || <component_clause>
+    ||  'replaceable' [
+      <class_definition> || <component_clause>
+    ]  [<constraining_clause> <comment>]?
   ]
 }
 
 rule import_clause {
-  <|w>'import'<|w>
-  [
-  [ <IDENT> '=' <name>] || <name> [ '.'[ '*' || [ '{' <import_list> '}' ] ] ]?
-  ]
-  <comment>
+  'import'  [
+    ||  <IDENT> '=' <name>
+    ||  <name> [ '.' [ '*' || '{' <import_list> '}' ] ]?
+  ]  <comment>
 }
 
 rule import_list { <IDENT> [ ',' <IDENT> ]* }

--- a/lib/Grammar/Modelica/ComponentClause.pm6
+++ b/lib/Grammar/Modelica/ComponentClause.pm6
@@ -9,8 +9,11 @@ rule component_clause {
 }
 
 rule type_prefix {
-  [<|w>[ 'flow' || 'stream' ]<|w>]?
-  [<|w>[ 'discrete' || 'parameter' || 'constant' ]<|w>]? [<|w>[ 'input' || 'output' ]<|w>]?
+  [ 'flow' || 'stream' ]?  [
+    ||  'discrete'
+    || 'parameter'
+    || 'constant'
+  ]? [ 'input' || 'output' ]?
 }
 
 rule component_list {

--- a/lib/Grammar/Modelica/Equations.pm6
+++ b/lib/Grammar/Modelica/Equations.pm6
@@ -25,7 +25,6 @@ rule equation {
 
 rule statement {
   [
-    ||  <component_reference> [ ':=' <expression> || <function_call_args> ]
     ||  '(' <output_expression_list> ')' ':=' <component_reference> <function_call_args>
     ||  'break'
     ||  'return'
@@ -33,6 +32,7 @@ rule statement {
     ||  <for_statement>
     ||  <while_statement>
     ||  <when_statement>
+    ||  <component_reference> [ ':=' <expression> || <function_call_args> ]
   ]
   <comment>
 }

--- a/lib/Grammar/Modelica/Equations.pm6
+++ b/lib/Grammar/Modelica/Equations.pm6
@@ -5,88 +5,87 @@ use v6;
 unit role Grammar::Modelica::Equations;
 
 rule equation_section {
-  [<|w>'initial'<|w>]? <|w>'equation'<|w> [ <equation> ';' ]*
+  'initial'? 'equation' [ <equation> ';' ]*
 }
 
 rule algorithm_section {
-  [<|w>'initial'<|w>]? <|w>'algorithm'<|w> [ <statement> ';' ]*
+  'initial'? 'algorithm' [ <statement> ';' ]*
 }
 
 rule equation {
   [
-  [<simple_expression> '=' <expression>] ||
-  <if_equation> ||
-  <for_equation> ||
-  <connect_clause> ||
-  <when_equation> ||
-  [<component_reference> <function_call_args>]
-  ]
-  <comment>
+    ||  <simple_expression> '=' <expression>
+    ||  <if_equation>
+    ||  <for_equation>
+    ||  <connect_clause>
+    ||  <when_equation>
+    ||  <component_reference> <function_call_args>
+  ]  <comment>
 }
 
 rule statement {
   [
-  [ <component_reference> [ [':=' <expression>] || <function_call_args> ]] ||
-  [ '(' <output_expression_list> ')' ':=' <component_reference> <function_call_args> ] ||
-  <|w>'break'<|w> ||
-  <|w>'return'<|w> ||
-  <if_statement> ||
-  <for_statement> ||
-  <while_statement> ||
-  <when_statement>
+    ||  <component_reference> [ ':=' <expression> || <function_call_args> ]
+    ||  '(' <output_expression_list> ')' ':=' <component_reference> <function_call_args>
+    ||  'break'
+    ||  'return'
+    ||  <if_statement>
+    ||  <for_statement>
+    ||  <while_statement>
+    ||  <when_statement>
   ]
   <comment>
 }
 
 rule if_equation {
-  <|w>'if'<|w> <expression> <|w>'then'<|w>
+  'if' <expression> 'then'
   [ <equation> ';' ]*
   [
-    <|w>'elseif'<|w> <expression> <|w>'then'<|w>
+    'elseif' <expression> 'then'
     [ <equation> ';' ]*
   ]*
   [
-    <|w>'else'<|w>
+    'else'
     [ <equation> ';' ]*
   ]?
 
-  <|w>'end'<|w> <|w>'if'<|w>
+  'end' 'if'
 }
 
 rule if_statement {
-  <|w>'if'<|w> <expression> <|w>'then'<|w>
+  'if' <expression> 'then'
   [ <statement> ';' ]*
   [
-    <|w>'elseif'<|w> <expression> <|w>'then'<|w>
+    'elseif' <expression> 'then'
     [ <statement> ';' ]*
   ]*
   [
-    <|w>'else'<|w>
+    'else'
     [ <statement> ';' ]*
   ]?
-  <|w>'end'<|w> <|w>'if'<|w>
+  'end' 'if'
 }
 
 rule for_equation {
-  <|w>'for'<|w> <for_indices> <|w>'loop'<|w>
+  'for' <for_indices> 'loop'
   [ <equation> ';' ]*
-  <|w>'end'<|w> <|w>'for'<|w>
+  'end' 'for'
 }
 
 rule for_statement {
-  <|w>'for'<|w> <for_indices> <|w>'loop'<|w>
+  'for' <for_indices> 'loop'
   [ <statement> ';' ]*
-  <|w>'end'<|w> <|w>'for'<|w>
+  'end' 'for'
 }
 
 rule for_indices { <for_index> [ ',' <for_index> ]* }
 
-rule for_index { <IDENT> ['in'<|w> <expression>]? }
+rule for_index { <IDENT> ['in' <expression>]? }
 
 rule while_statement {
-  <|w>'while'<|w> <expression> <|w>'loop'<|w>
+  'while' <expression> 'loop'
   [ <statement> ';' ]*
-  <|w>'end'<|w> <|w>'while'<|w>
+  'end' 'while'
 }
 
 rule when_equation {
@@ -96,19 +95,19 @@ rule when_equation {
   <|w>'elsewhen'<|w> <expression> <|w>'then'<|w>
   [ <equation> ';' ]*
   ]*
-  <|w>'end'<|w> <|w>'when'<|w>
+  'end' 'when'
 }
 
 rule when_statement {
-  <|w>'when'<|w> <expression> <|w>'then'<|w>
+  'when' <expression> 'then'
   [ <statement> ';' ]*
   [
-  <|w>'elsewhen'<|w> <expression> <|w>'then'<|w>
+  'elsewhen' <expression> 'then'
   [ <statement> ';' ]*
   ]*
-  <|w>'end'<|w> <|w>'when'<|w>
+  'end' 'when'
 }
 
 rule connect_clause {
-  <|w>'connect'<|w> '(' <component_reference> ',' <component_reference> ')'
+  'connect' '(' <component_reference> ',' <component_reference> ')'
 }

--- a/lib/Grammar/Modelica/Expressions.pm6
+++ b/lib/Grammar/Modelica/Expressions.pm6
@@ -5,14 +5,11 @@ use v6;
 unit role Grammar::Modelica::Expressions;
 
 rule expression {
-  [
-  <|w>'if'<|w> <expression> <|w>'then'<|w> <expression> [
-  <|w>'elseif'<|w> <expression> <|w>'then'<|w> <expression>
-  ]*
-  <|w>'else'<|w> <expression>
-  ]
-  ||
-  <simple_expression>
+  ||  'if' <expression> 'then' <expression> [
+        'elseif' <expression> 'then' <expression>
+      ]*
+      'else' <expression>
+  ||  <simple_expression>
 }
 
 rule simple_expression {
@@ -24,15 +21,15 @@ rule simple_expression {
 }
 
 rule logical_expression {
-  <logical_term> [ <|w>'or'<|w> <logical_term> ]*
+  <logical_term> [ 'or' <logical_term> ]*
 }
 
 rule logical_term {
-  <logical_factor> [ <|w>'and'<|w> <logical_factor> ]*
+  <logical_factor> [ 'and' <logical_factor> ]*
 }
 
 rule logical_factor {
-  [<|w>'not'<|w>]? <relation>
+  'not'? <relation>
 }
 
 rule relation {
@@ -49,21 +46,21 @@ rule term {
 
 rule factor {
   <primary> [
-  [ '^' || '.^' ] <primary>
+    [ '^' || '.^' ] <primary>
   ]?
 }
 
 rule primary {
-  <UNSIGNED_NUMBER> ||
-  <STRING> ||
-  <|w>'false'<|w> ||
-  <|w>'true'<|w> ||
-  [ [<component_reference>||'der'||'initial'||'pure'] <function_call_args> ] ||
-  <component_reference> ||
-  [ '(' <output_expression_list> ')' ] ||
-  [ '[' <expression_list> [ ';' <expression_list> ]* ']' ] ||
-  [ '{' <array_arguments> '}' ] ||
-  <|w>'end'<|w>
+  ||  <UNSIGNED_NUMBER>
+  ||  <STRING>
+  ||  'false'
+  ||  'true'
+  ||  [<component_reference>||'der'||'initial'||'pure'] <function_call_args>
+  ||  <component_reference>
+  ||  '(' <output_expression_list> ')'
+  ||  '[' <expression_list> [ ';' <expression_list> ]* ']'
+  ||  '{' <array_arguments> '}'
+  ||  'end'
 }
 
 token type_specifier {"."?<name>}
@@ -79,9 +76,9 @@ rule function_call_args {
 }
 
 rule function_arguments {
-  [ <|w>'function'<|w> <name> '(' <named_arguments>? ')'  [ ',' <function_arguments_non_first> ]? ] ||
-  <named_arguments> ||
-  [ <expression> [ [ ',' <function_arguments_non_first> ] || [ <|w>'for'<|w> <for_indices>] ]? ]
+  ||  <|w>'function'<|w> <name> '(' <named_arguments>? ')'  [ ',' <function_arguments_non_first> ]?
+  ||  <named_arguments>
+  ||  <expression> [ [ ',' <function_arguments_non_first> ] || [ <|w>'for'<|w> <for_indices>] ]?
 }
 
 rule function_arguments_non_first {
@@ -90,13 +87,14 @@ rule function_arguments_non_first {
 }
 
 rule array_arguments {
-  <expression>
-  [ ',' <array_arguments_non_first> || [ <|w>'for'<|w> <for_indices> ] ]?
+  <expression>  [
+    ||',' <array_arguments_non_first>
+    || 'for' <for_indices>
+  ]?
 }
 
 rule array_arguments_non_first {
-  <expression>
-  [ ',' <array_arguments_non_first> ]?
+  <expression>  [ ',' <array_arguments_non_first> ]?
 }
 
 rule named_arguments {
@@ -126,7 +124,7 @@ rule string_comment { <ws>? [ <STRING> [ '+' <STRING> ]* ]? }
 
 rule comment { <string_comment> <annotation>? }
 
-rule annotation { <|w>'annotation'<|w> <class_modification> }
+rule annotation { 'annotation' <class_modification> }
 
 token add_operator {'+'|'-'|'.+'|'.-'}
 

--- a/lib/Grammar/Modelica/LexicalConventions.pm6
+++ b/lib/Grammar/Modelica/LexicalConventions.pm6
@@ -32,7 +32,7 @@ token UNSIGNED_NUMBER {<UNSIGNED_INTEGER>+['.'<UNSIGNED_INTEGER>?]?[<[eE]><[+-]>
 
 token c-comment {['//'.*?$$]||['/*'.*?'*/']}
 
-token ws { [\s|<c-comment>]* }
+token ws { <!ww>[\s|<c-comment>]* }
 
 token keywords {
   <|w>[ 'within'

--- a/lib/Grammar/Modelica/Modification.pm6
+++ b/lib/Grammar/Modelica/Modification.pm6
@@ -5,9 +5,9 @@ use v6;
 unit role Grammar::Modelica::Modification;
 
 rule modification {
-  [<class_modification> ['=' <expression>]?] ||
-  [':=' <expression>] ||
-  ['=' <expression>]
+  ||  <class_modification> ['=' <expression>]?
+  ||  ':=' <expression>
+  ||  '=' <expression>
 }
 
 rule class_modification {
@@ -21,7 +21,7 @@ rule argument_list {
 token argument {<element_modification_or_replaceable>||<element_redeclaration>}
 
 rule element_modification_or_replaceable {
-  [<|w>'each'<|w>]? [<|w>'final'<|w>]? [<element_modification> || <element_replaceable>]
+  'each'? 'final'? [<element_modification> || <element_replaceable>]
 }
 
 rule element_modification {
@@ -29,12 +29,12 @@ rule element_modification {
 }
 
 rule element_redeclaration {
-  <|w>'redeclare'<|w> [<|w>'each'<|w>]? [<|w>'final'<|w>]?
+  'redeclare' 'each'? 'final'?
   [ [ <short_class_definition> || <component_clause1>] || <element_replaceable> ]
 }
 
 rule element_replaceable {
-  <|w>'replaceable'<|w> [<short_class_definition> || <component_clause1>]
+  'replaceable' [<short_class_definition> || <component_clause1>]
   <constraining_clause>?
 }
 


### PR DESCRIPTION
It's a bigger change but now all Modelica Standard Library cases pass as well as tests.  Big rewrite and restructuring is described in one of the commit messages, but I'll include it here.

Change definition of `<ws>` in LexicalConventions.pm6 so that dozens of `<|w>` tests in the grammar can be removed.  Change in `<ws>` is based on [Perl 6 doc issue 1729 - <.ws> poorly defined](https://github.com/perl6/doc/issues/1729).  Remove very many unneeded brackets by relying on low precedence of `||` and use removal of brackets and Perl 6
intentionally ignoring empty leading `||` in series of sequential disjunctions to improve readability.  All tests pass and one additional Modelica Standard Library test passes.  Time to run Modelica Standard Lib is inconsistent but sometimes under six minutes on my 3.6GHz Core i7.