### PR TITLE
Update META6.json to fix Ecosystem Toaster error

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,6 @@
         "Grammar::Modelica::Modification" : "lib/Grammar/Modelica/Modification.pm6"
     },
     "depends" : [ ],
-    "test-depends" : [ "Test::Meta" ],
     "resources" : [ ],
     "source-url" : "git://github.com/albastev/Grammar-Modelica.git"
 }


### PR DESCRIPTION
I doesn't look like testing depends on `Test::Meta` and the dependency is breaking ecosystem toasting: https://toast.perl6.party/module?module=Grammar::Modelica&commit=2018.06