### PR TITLE
Update META6.json fix Ecosystem Toaster error (2nd try)

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,7 @@
         "Grammar::Modelica::Modification" : "lib/Grammar/Modelica/Modification.pm6"
     },
     "depends" : [ ],
-    "test-depends" : [ "Test::Meta" ],
+    "test-depends" : [ "Test", "Test::META" ],
     "resources" : [ ],
     "source-url" : "git://github.com/albastev/Grammar-Modelica.git"
 }


### PR DESCRIPTION
`Test::Meta` should have been `Test::META` which is why ecosystem toasting couldn't find the dependency: https://toast.perl6.party/module?module=Grammar::Modelica&commit=2018.06

Should be better fix than my last one.